### PR TITLE
Fix for Slack Listen. "txt" replaced with "text"

### DIFF
--- a/slack/82_slack_listen.js
+++ b/slack/82_slack_listen.js
@@ -16,7 +16,7 @@ module.exports = function(RED) {
 
             this.slack.slackClient.on('message', function(message) {
                 var msg = {
-                    payload: message.txt
+                    payload: message.text //Changed txt to text. Possibly a change to the Slack API that hadn't filtered through
                 };
 
                 var slackChannel = slack.slackClient.getChannelGroupOrDMByID(message.channel);


### PR DESCRIPTION
(Possibly an outdated call to the Slack API)